### PR TITLE
createResponse & destroyResponse

### DIFF
--- a/src/main/java/com/incarcloud/rooster/datapack/Any4DataParser.java
+++ b/src/main/java/com/incarcloud/rooster/datapack/Any4DataParser.java
@@ -22,4 +22,14 @@ public class Any4DataParser implements IDataParser {
 
         return listPacks;
     }
+
+    @Override
+    public ByteBuf createResponse(DataPack requestPack, ERespReason reason) {
+        return null;
+    }
+
+    @Override
+    public void destroyResponse(ByteBuf responseBuf) {
+
+    }
 }

--- a/src/main/java/com/incarcloud/rooster/datapack/ERespReason.java
+++ b/src/main/java/com/incarcloud/rooster/datapack/ERespReason.java
@@ -1,0 +1,11 @@
+package com.incarcloud.rooster.datapack;
+
+/**
+ * 应答原因
+ */
+public enum ERespReason {
+    NA,
+    OK,
+    Failed,
+    Heartbeat
+}

--- a/src/main/java/com/incarcloud/rooster/datapack/ERespReason.java
+++ b/src/main/java/com/incarcloud/rooster/datapack/ERespReason.java
@@ -6,6 +6,5 @@ package com.incarcloud.rooster.datapack;
 public enum ERespReason {
     NA,
     OK,
-    Failed,
-    Heartbeat
+    Failed
 }

--- a/src/main/java/com/incarcloud/rooster/datapack/IDataParser.java
+++ b/src/main/java/com/incarcloud/rooster/datapack/IDataParser.java
@@ -5,8 +5,12 @@ import io.netty.buffer.ByteBuf;
 import java.util.List;
 
 public interface IDataParser {
-     // 抽取出完整有效的数据包,并从buffer丢弃掉已经解析或无用的字节
-     List<DataPack> extract(ByteBuf buffer);
+    // 抽取出完整有效的数据包,并从buffer丢弃掉已经解析或无用的字节
+    List<DataPack> extract(ByteBuf buffer);
+    // 创建应答数据包
+    ByteBuf createResponse(DataPack requestPack, ERespReason reason);
+    // 销毁应答数据包
+    void destroyResponse(ByteBuf responseBuf);
 }
 
 


### PR DESCRIPTION
IDataParser中增加了2个接口用于应答过程
```java
public interface IDataParser {
    // 抽取出完整有效的数据包,并从buffer丢弃掉已经解析或无用的字节
    List<DataPack> extract(ByteBuf buffer);
    // 创建应答数据包
    ByteBuf createResponse(DataPack requestPack, ERespReason reason);
    // 销毁应答数据包
    void destroyResponse(ByteBuf responseBuf);
}
```

[GatherPortType.java#L54-L66](https://github.com/InCar/rooster-gather/blob/79cad018cdfc6868f7fc2b6b307ebc86a8f8ceca/src/main/java/com/incarcloud/rooster/gather/GatherPortType.java#L54-L66)

当OnRead收到数据包后，使用IDataParser.extract进行解析
+ 当成功发送到MQ上后，有的协议要求向设备发送一个成功应答，有的不需要
+ 当发送到MQ失败，有的协议要求向设备发送一个失败应答，有的不需要

此接口这样定义是否可行？